### PR TITLE
Implement variable to use separate database for mocha tests

### DIFF
--- a/config/mongoConnection.js
+++ b/config/mongoConnection.js
@@ -1,19 +1,21 @@
-const MongoClient = require('mongodb').MongoClient;
-const settings = require('./settings');
+const MongoClient = require("mongodb").MongoClient;
+const settings = require("./settings");
 
 const mongoConfig = settings.mongoConfig;
+
+if (global.isTesting) mongoConfig.database = mongoConfig.testDatabase;
 
 let _connection = undefined;
 let _db = undefined;
 
 module.exports = async () => {
-	if (!_connection) {
-		_connection = await MongoClient.connect(mongoConfig.serverUrl, {
-			useNewUrlParser: true,
-			useUnifiedTopology: true
-		});
-		_db = await _connection.db(mongoConfig.database);
-	}
+  if (!_connection) {
+    _connection = await MongoClient.connect(mongoConfig.serverUrl, {
+      useNewUrlParser: true,
+      useUnifiedTopology: true,
+    });
+    _db = await _connection.db(mongoConfig.database);
+  }
 
-	return _db;
+  return _db;
 };

--- a/config/settings.json
+++ b/config/settings.json
@@ -1,6 +1,7 @@
 {
   "mongoConfig": {
     "serverUrl": "mongodb://localhost:27017/",
-    "database": "Music_Sharing_Service"
+    "database": "Music_Sharing_Service",
+    "testDatabase": "test_Music_Sharing_Service"
   }
 }

--- a/test/common.js
+++ b/test/common.js
@@ -1,4 +1,6 @@
 const chai = require("chai");
+// Set global testing flag to true
+global.isTesting = true;
 
 const chaiHttp = require("chai-http");
 chai.use(chaiHttp);


### PR DESCRIPTION
This enables mocha tests to safely delete elements from the database for testing, without ever interfering with the production database.  This is not the best way to implement this, but it will work for now until we potentially rewrite the MongoDB connection handler or switch to using Mongoose.