### PR TITLE
Add afterEach database drop function to all db unit tests

### DIFF
--- a/test/database_tests/comments.js
+++ b/test/database_tests/comments.js
@@ -5,6 +5,11 @@ after(async () => {
   await db.serverConfig.close();
 });
 
+afterEach(async () => {
+  const db = await mongoConnection();
+  await db.dropDatabase();
+});
+
 describe("Comments DB Collection", function () {
   describe("addComment()", function () {
     it("should return the added comment object when passed ObjectId types", async function () {

--- a/test/database_tests/songs.js
+++ b/test/database_tests/songs.js
@@ -5,6 +5,11 @@ after(async () => {
   await db.serverConfig.close();
 });
 
+afterEach(async () => {
+  const db = await mongoConnection();
+  await db.dropDatabase();
+});
+
 describe("Songs DB Collection", function () {
   describe("addSong()", function () {
     it("should return the added song object when passed details", async function () {

--- a/test/database_tests/users.js
+++ b/test/database_tests/users.js
@@ -5,6 +5,11 @@ after(async () => {
   await db.serverConfig.close();
 });
 
+afterEach(async () => {
+  const db = await mongoConnection();
+  await db.dropDatabase();
+});
+
 describe("Users DB Collection", function () {
   describe("addUser()", function () {
     it("should return the added user object when passed user attributes", async function () {


### PR DESCRIPTION
This PR ensures that database tests are atomic in nature.  After each individual test is run, the test MongoDB database is dropped, preventing unexpected behavior during testing due to persistent database entries.